### PR TITLE
修复与 avbroot 不能一起使用的问题

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -450,7 +450,7 @@ jobs:
         run: |
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG"
-
+          sed -i '$s|echo "\$res"|echo "\$res-0D000721"|' ./common/scripts/setlocalversion
           if [ ! -z ${{ inputs.version }} ]; then
             echo "版本号不为空"
             sed -i '$s|echo "\$res"|echo "${{ inputs.version }}"|' ./common/scripts/setlocalversion

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -456,7 +456,7 @@ jobs:
             sed -i '$s|echo "\$res"|echo "${{ inputs.version }}"|' ./common/scripts/setlocalversion
           else
             echo "版本号为空，使用默认值"
-            sed -i '$s|echo "\$res"|echo "\$res-0D000721"|' ./common/scripts/setlocalversion
+            sed -i '$s|echo "\$res"|echo "\$res-zakozakoooooo-1145141919"|' ./common/scripts/setlocalversion
           fi
 
           # Run perl command to modify UTS_VERSION

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -450,10 +450,13 @@ jobs:
         run: |
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG"
-          sed -i '$s|echo "\$res"|echo "\$res-0D000721"|' ./common/scripts/setlocalversion
+          
           if [ ! -z ${{ inputs.version }} ]; then
             echo "版本号不为空"
             sed -i '$s|echo "\$res"|echo "${{ inputs.version }}"|' ./common/scripts/setlocalversion
+          else
+            echo "版本号为空，使用默认值"
+            sed -i '$s|echo "\$res"|echo "\$res-0D000721"|' ./common/scripts/setlocalversion
           fi
 
           # Run perl command to modify UTS_VERSION


### PR DESCRIPTION
注意到

https://github.com/chenxiaolong/avbroot/blob/b1410c869d8b33567dcede41176e59348dcd6b61/avbroot/src/patch/boot.rs#L900

正则表达式 `Linux version ([0-9]+\.[0-9]+).[0-9]+-(android[0-9]+)-([0-9]+)-`，需要在末尾有横杠。这里给内核末尾添加了`-0D000721` 尝试修复这个问题。